### PR TITLE
Fix link decoration for enhanced rendering

### DIFF
--- a/lib/asciidoctor-lists/extensions.rb
+++ b/lib/asciidoctor-lists/extensions.rb
@@ -51,13 +51,13 @@ module AsciidoctorLists
 
                if enhanced_rendering
                    if element.caption
-                     references_asciidoc << %(xref:#{element.id}[#{element.caption}]#{element.instance_variable_get(:@title)} +)
+                     references_asciidoc << %(xref:#{element.id}[#{element.caption.rstrip()}] #{element.instance_variable_get(:@title)} +)
                    else element.caption
                      references_asciidoc << %(xref:#{element.id}[#{element.instance_variable_get(:@title)}] +)
                    end
                  else
                    if element.caption
-                    references_asciidoc << %(xref:#{element.id}[#{element.caption}]#{element.title} +)
+                    references_asciidoc << %(xref:#{element.id}[#{element.caption.rstrip()}] #{element.title} +)
                    else element.caption
                     references_asciidoc << %(xref:#{element.id}[#{element.title}] +)
                  end

--- a/lib/asciidoctor-lists/extensions.rb
+++ b/lib/asciidoctor-lists/extensions.rb
@@ -52,13 +52,13 @@ module AsciidoctorLists
                if enhanced_rendering
                    if element.caption
                      references_asciidoc << %(xref:#{element.id}[#{element.caption.rstrip()}] #{element.instance_variable_get(:@title)} +)
-                   else element.caption
+                   else
                      references_asciidoc << %(xref:#{element.id}[#{element.instance_variable_get(:@title)}] +)
                    end
                  else
                    if element.caption
                     references_asciidoc << %(xref:#{element.id}[#{element.caption.rstrip()}] #{element.title} +)
-                   else element.caption
+                   else
                     references_asciidoc << %(xref:#{element.id}[#{element.title}] +)
                  end
                end


### PR DESCRIPTION
When using the enhanced rendering and caption numbering, the caption link doesn't have a space to the title (when a caption is present). I believe the numbered caption is stored with a space at the end of the string for the "normal" numbering throughout the document. This confuses the link decoration and just assumes all whitespace after it belongs to the link as well. This leads to wrong display in the lists:

Current behavior:
![image](https://github.com/Alwinator/asciidoctor-lists/assets/4920542/47b624eb-6472-493a-a518-9f609a3f5089)

Space stripped from caption:
![image](https://github.com/Alwinator/asciidoctor-lists/assets/4920542/d6064b38-3f52-45f1-9751-5e73d4d89e27)

I've also removed the unnecessary stuff from the else conditions for these cases.
