### PR TITLE
Fixed: possible invalid reference

### DIFF
--- a/lib/asciidoctor-lists/extensions.rb
+++ b/lib/asciidoctor-lists/extensions.rb
@@ -47,6 +47,7 @@ module AsciidoctorLists
              if element.caption or element.title
                unless element.id
                  element.id = SecureRandom.uuid
+                 document.catalog[:refs][element.id] = element
                end
 
                if enhanced_rendering


### PR DESCRIPTION
Just added random refs to asset :refs and the warnings go away